### PR TITLE
Made tables take up full-width on mobile

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -123,8 +123,8 @@ h3 {
   text-transform: uppercase;
   font-weight: bold;
   background-color: #83c6ff;
+  margin: 0 -9.2308vw 0.2em -9.2308vw; /* Negate html padding on mobile */
   padding: 0.5em 0 0.5em 0.3em;
-  margin-bottom: 0.2em;
 }
 
 h4 {
@@ -299,19 +299,19 @@ nav {
 }
 
 
-/* Table */
+/* Table - full width on mobile */
 table {
-	table-layout: fixed;
-	width: 750px;
-  margin-bottom: 1em;
+  table-layout: fixed;
+  width: 100vw;
+  margin: 0 -9.2308vw 1em -9.2308vw; /* Negate html padding on mobile */
 }
 table, th, td {
-	border: 1px solid #59453C;
-	padding: 0px 10px;
+  border: 1px solid #59453C;
+  padding: 0px 5px;
 }
 .tablehead {
-	background-color: #83c6ff;
-	text-align: center;
+  background-color: #83c6ff;
+  text-align: center;
   font-weight: 700;
 }
 .tabletitle {
@@ -323,48 +323,46 @@ table, th, td {
   margin-bottom: 0;
 }
 tr .firstrow {
-	border-right: none;
-	width: 75px;
+  border-right: none;
+  width: 75px;
 }
 tr .secondrow {
-	text-align: left;
+  text-align: left;
 }
 td a {
-	font-weight: 700;
-	text-align: center;
+  font-weight: 700;
+  text-align: center;
 }
 td {
-	text-align: center;
+  text-align: center;
+  font-size: 1rem;
 }
 .nobullet {
   list-style: none;
 }
 .alignleft {
-	text-align: left;
+  text-align: left;
   padding-top: 5px;
 }
 .short {
   width: 120px;
 }
 .redfont {
-	color: red;
+  color: red;
 }
 .darkredfont {
   color: #d70000;
 }
 #tablep {
-	width: 80%
+  width: 80%
 }
 .addeventstc {
-	margin: 10px;
-	margin-left: 30%;
-	margin-right: 30%;
-}
-#h3wide {
-  width: 750px;
+  margin: 10px;
+  margin-left: 30%;
+  margin-right: 30%;
 }
 
-/* Policies */ 
+/* Policies */
 
 .indent {
   margin-left: 2em;
@@ -478,7 +476,7 @@ td {
     width: 42.5%;
     margin-right: 0;
   }
-  
+
   #essential-references {
     position: absolute;
     top: 0px;
@@ -489,6 +487,13 @@ td {
 }
 
 @media screen and (min-width: 804px) {
+  table {
+    width: 750px;
+    margin: 0 0 1em 0; /* Normal table margins */
+  }
+  h3 {
+    margin: 0 0 0.2em 0; /* Normal h3 margins */
+  }
   .flexbox .agenda > ol {
     display: flex; /* My life for element/container queries...*/
   }

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         </ul>
       </nav>
     </header>
-    
+
     <main id="content">
       <article class="primary">
         <h2 class="label">Course Calendar</h2>
@@ -35,12 +35,10 @@
         </p>
         <p class="redfont">Work which fails HTML or CSS validation will receive a 50&#x25; point reduction!</p>
         <section class="topics">
-          <table id="protable">
+          <table>
             <tr class="tablehead">
-              <td class="tabletitle" colspan="1">Topic Schedule&#58;</td>
+              <td class="tabletitle" colspan="3">Topic Schedule&#58;</td>
             </tr>
-          </table>
-          <table>  
             <tr class="tablehead">
               <td class="firstrow">Date</td>
               <td class="short">Topic</td>
@@ -246,35 +244,35 @@
             </tr>
             <tr>
               <td>01/30</td>
-              <td class="center">Lab-1</td>
+              <td class="alignleft">Lab-1</td>
             </tr>
             <tr>
               <td>02/13</td>
-              <td class="center">Lab-2</td>
+              <td class="alignleft">Lab-2</td>
             </tr>
             <tr>
               <td>02/13</td>
-              <td class="center">Lab-3</td>
+              <td class="alignleft">Lab-3</td>
             </tr>
             <tr>
               <td>03/06</td>
-              <td class="center">Lab-4</td>
+              <td class="alignleft">Lab-4</td>
             </tr>
             <tr>
               <td>03/13</td>
-              <td class="center">Lab-5</td>
+              <td class="alignleft">Lab-5</td>
             </tr>
             <tr>
               <td>03/27</td>
-              <td class="center">Lab-6</td>
+              <td class="alignleft">Lab-6</td>
             </tr>
             <tr>
               <td>04/03</td>
-              <td class="center">Lab-7</td>
+              <td class="alignleft">Lab-7</td>
             </tr>
             <tr>
               <td>04/10</td>
-              <td class="center">Lab-8</td>
+              <td class="alignleft">Lab-8</td>
             </tr>
             <tr>
               <td></td>
@@ -282,15 +280,15 @@
             </tr>
             <tr>
               <td>02/20</td>
-              <td class="center">First Turn In</td>
+              <td class="alignleft">First Turn In</td>
             </tr>
             <tr>
               <td>02/27</td>
-              <td class="center">Comments Due</td>
+              <td class="alignleft">Comments Due</td>
             </tr>
             <tr>
               <td>03/06</td>
-              <td class="center">Final Turn In</td>
+              <td class="alignleft">Final Turn In</td>
             </tr>
             <tr>
               <td></td>
@@ -298,19 +296,19 @@
             </tr>
             <tr>
               <td>03/20</td>
-              <td class="center">Task Analysis Due</td>
+              <td class="alignleft">Task Analysis Due</td>
             </tr>
             <tr>
               <td>04/03</td>
-              <td class="center">First Turn In</td>
+              <td class="alignleft">First Turn In</td>
             </tr>
             <tr>
               <td>04/10</td>
-              <td class="center">Comments Due</td>
+              <td class="alignleft">Comments Due</td>
             </tr>
             <tr>
               <td>04/24</td>
-              <td class="center">Final Turn In</td>
+              <td class="alignleft">Final Turn In</td>
             </tr>
             <tr>
               <td></td>
@@ -318,13 +316,13 @@
             </tr>
             <tr>
               <td>04/24</td>
-              <td class="center">First and Only Turn In</td>
+              <td class="alignleft">First and Only Turn In</td>
             </tr>
           </table>
-        </section>        
+        </section>
       </article>
     </main>
-  
+
    <aside id="links">
     <h3 id="h3wide">Important Links</h3>
     <div class="link-group">
@@ -397,5 +395,4 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
   <script src="site.js"></script>
 </body>
-</html> 
- 
+</html>


### PR DESCRIPTION
Also cut font-size and padding to make items fit.

Previously, it looked like so:

![image](https://user-images.githubusercontent.com/3187531/38230852-9cd8b66a-36d5-11e8-9bb5-e26005dfa41e.png)

Now it looks like this:
![image](https://user-images.githubusercontent.com/3187531/38230866-ae148c06-36d5-11e8-8c9c-bb96525135ee.png)

Although not perfect, this makes the entire schedule table relatively readable on mobile, and generally makes it so you don't have to scroll horizontally on mobile (which included a fixing a weird `h3`).
